### PR TITLE
Faster propertynames when no dynamic properties are present

### DIFF
--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -118,10 +118,19 @@ macro dynamic(expr::Expr)
 
     return quote
         $(esc(expr))
-
-        function Base.propertynames(x::$(esc(struct_name)), private::Bool=false)
-            fields = private ? fieldnames(typeof(x)) : fieldnames(typeof(x))[1:end-1]
-            fields..., keys(property_dict(x))...
+        function Base.propertynames(x::$struct_name)
+            if isempty($property_dict(x)) 
+                fieldnames(typeof(x))[1:end-1]
+            else
+                (fieldnames(typeof(x))[1:end-1]..., keys($property_dict(x))...)
+            end
+        end
+        function Base.propertynames(x::$struct_name, private::Bool)
+            if private
+                (fieldnames(typeof(x))..., keys($property_dict(x))...)
+            else
+                Base.propertynames(x)
+            end
         end
 
         function Base.getproperty(x::$(esc(struct_name)), name::Symbol)

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -118,16 +118,16 @@ macro dynamic(expr::Expr)
 
     return quote
         $(esc(expr))
-        function Base.propertynames(x::$struct_name)
-            if isempty($property_dict(x)) 
+        function Base.propertynames(x::$(esc(struct_name)))
+            if isempty(property_dict(x)) 
                 fieldnames(typeof(x))[1:end-1]
             else
-                (fieldnames(typeof(x))[1:end-1]..., keys($property_dict(x))...)
+                (fieldnames(typeof(x))[1:end-1]..., keys(property_dict(x))...)
             end
         end
-        function Base.propertynames(x::$struct_name, private::Bool)
+        function Base.propertynames(x::$(esc(struct_name)), private::Bool)
             if private
-                (fieldnames(typeof(x))..., keys($property_dict(x))...)
+                (fieldnames(typeof(x))..., keys(property_dict(x))...)
             else
                 Base.propertynames(x)
             end


### PR DESCRIPTION
```julia
julia> using DynamicStructs, BenchmarkTools

julia> @dynamic struct Spaceship
           name::String
       end

julia> ship = Spaceship("Hail Mary")
Spaceship:
  1 field:
    name::String = "Hail Mary"
  no properties:

julia> @benchmark propertynames($ship)

#now
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  3.366 ns … 9.157 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.417 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.428 ns ± 0.184 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                 ▂         ▇█                                
  ▂▁▁▁▁▇▁▁▁▁▄▁▁▁▁█▁▁▁▁▄▃▁▁▁██▁▁▁▇▇▁▁▁▃▄▁▁▁▁▄▁▁▁▁▂▁▁▁▁▄▁▁▁▁▂ ▃
  3.37 ns        Histogram: frequency by time       3.48 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

#before
BenchmarkTools.Trial: 10000 samples with 961 evaluations.
 Range (min … max):   87.211 ns … 449.909 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     110.210 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   111.196 ns ±  10.671 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                        ▁▃▇█▇█▇▄▂▁▁              
  ▂▁▁▁▁▁▁▁▁▁▂▂▂▂▁▁▂▂▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▃▄▆████████████▇▇▆▅▄▄▃▃▃▂▂▂ ▄
  87.2 ns          Histogram: frequency by time          119 ns <

 Memory estimate: 32 bytes, allocs estimate: 2.
```