### PR TITLE
Add lazy `DynamicProperties` type and use `LittleDict`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "DynamicStructs"
 uuid = "e139c391-eeee-4818-b359-c8725224fb1f"
 authors = ["Anton Oresten <anton.oresten42@gmail.com> and contributors"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
 OrderedCollections = "1"
-julia = "^1.6"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/DynamicStructs.jl
+++ b/src/DynamicStructs.jl
@@ -1,6 +1,6 @@
 module DynamicStructs
 
-using OrderedCollections: OrderedDict
+using OrderedCollections
 
 export getproperties
 export isdynamictype, isdynamic

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -1,4 +1,18 @@
+
+
+mutable struct DYNAMIC_PROPERTIES
+    dict::OrderedDict{Symbol, Any}
+    function DYNAMIC_PROPERTIES(; kwargs...)
+        isempty(kwargs) && return new()
+        return new(OrderedDict{Symbol,Any}(kwargs...))
+    end
+end
+
 const DYNAMIC_PROPERTIES_FIELD_NAME = :_dynamic_properties
+
+is_property_dict(x) = isdefined(getfield(x, DYNAMIC_PROPERTIES_FIELD_NAME), :dict)
+is_empty_property_dict(x) = !is_property_dict(x) || isempty(property_dict(x))
+set_property_dict(x) = setfield!(getfield(x, DYNAMIC_PROPERTIES_FIELD_NAME), :dict, OrderedDict{Symbol,Any}())
 
 """
     isdynamictype(T)
@@ -14,7 +28,7 @@ Check if `x` is an instance of a dynamic type.
 """
 isdynamic(@nospecialize x) = isdynamictype(typeof(x))
 
-@inline property_dict(x) = getfield(x, DYNAMIC_PROPERTIES_FIELD_NAME)
+@inline property_dict(x) = getfield(x, DYNAMIC_PROPERTIES_FIELD_NAME).dict
 
 delproperty!(x, name::Symbol) = (delete!(property_dict(x), name); x)
 
@@ -101,51 +115,56 @@ macro dynamic(expr::Expr)
     constructors = if isempty(type_param_names)
         quote
             $struct_name($(field_type_asserts...); kwargs...) =
-                new($(fields...), $OrderedDict{Symbol,Any}(kwargs...))
+                new($(fields...), $DYNAMIC_PROPERTIES(; kwargs...))
         end
     else
         quote
             $struct_name($(field_type_asserts...); kwargs...) where {$(type_param_names...)} =
-                new{$(type_param_names...)}($(fields...), $OrderedDict{Symbol,Any}(kwargs...))
+                new{$(type_param_names...)}($(fields...), $DYNAMIC_PROPERTIES(; kwargs...))
                 
             $struct_name{$(type_param_names...)}($(fields...); kwargs...) where {$(type_param_names...)} =
-                new{$(type_param_names...)}($(fields...), $OrderedDict{Symbol,Any}(kwargs...))
+                new{$(type_param_names...)}($(fields...), $DYNAMIC_PROPERTIES(; kwargs...))
         end
     end
 
-    push!(struct_body, :($DYNAMIC_PROPERTIES_FIELD_NAME::$OrderedDict{Symbol,Any}))
+    push!(struct_body, :($DYNAMIC_PROPERTIES_FIELD_NAME::$DYNAMIC_PROPERTIES))
     append!(struct_body, constructors.args)
 
     return quote
         $(esc(expr))
 
         function Base.propertynames(x::$(esc(struct_name)))
-            isempty(property_dict(x)) && return fieldnames(typeof(x))[1:end-1]
+            is_empty_property_dict(x) && return fieldnames(typeof(x))[1:end-1]
             (fieldnames(typeof(x))[1:end-1]..., keys(property_dict(x))...)
         end
 
         function Base.propertynames(x::$(esc(struct_name)), private::Bool)
+            private && is_empty_property_dict(x) && return fieldnames(typeof(x))
             private && return (fieldnames(typeof(x))..., keys(property_dict(x))...)
             Base.propertynames(x)
         end
 
         function Base.getproperty(x::$(esc(struct_name)), name::Symbol)
             hasfield(typeof(x), name) && return getfield(x, name)
-            name in keys(property_dict(x)) && return @inbounds getindex(property_dict(x), name)
+            is_property_dict(x) && name in keys(property_dict(x)) && return @inbounds getindex(property_dict(x), name)
             throw(ErrorException("$(typeof(x)) instance has no field or property $name"))
         end
 
         function Base.setproperty!(x::$(esc(struct_name)), name::Symbol, value)
             hasfield(typeof(x), name) && return setfield!(x, name, value)
+            !is_property_dict(x) && set_property_dict(x)
             setindex!(property_dict(x), value, name)
         end
 
         function Base.hash(x::$(esc(struct_name)), h::UInt)
+            !is_property_dict(x) && set_property_dict(x)
             field_hash = foldr(hash, getfield(x, fieldname) for fieldname in fieldnames(typeof(x)); init=h)
             hash(typeof(x), field_hash)
         end
 
         function Base.:(==)(x::$(esc(struct_name)), y::$(esc(struct_name)))
+            !is_property_dict(x) && set_property_dict(x)
+            !is_property_dict(y) && set_property_dict(y)
             !any(name -> getfield(x, name) != getfield(y, name), fieldnames(typeof(x)))
         end
 

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -1,18 +1,16 @@
-
-
-mutable struct DYNAMIC_PROPERTIES
-    dict::OrderedDict{Symbol, Any}
-    function DYNAMIC_PROPERTIES(; kwargs...)
-        isempty(kwargs) && return new()
-        return new(OrderedDict{Symbol,Any}(kwargs...))
-    end
+mutable struct DynamicProperties
+    dict::LittleDict{Symbol,Any}
+    DynamicProperties(; kwargs...) = isempty(kwargs) ? new() : new(LittleDict{Symbol,Any}(kwargs...))
 end
 
 const DYNAMIC_PROPERTIES_FIELD_NAME = :_dynamic_properties
 
-is_property_dict(x) = isdefined(getfield(x, DYNAMIC_PROPERTIES_FIELD_NAME), :dict)
-is_empty_property_dict(x) = !is_property_dict(x) || isempty(property_dict(x))
-set_property_dict(x) = setfield!(getfield(x, DYNAMIC_PROPERTIES_FIELD_NAME), :dict, OrderedDict{Symbol,Any}())
+@inline dynamic_properties(x)::DynamicProperties = getfield(x, DYNAMIC_PROPERTIES_FIELD_NAME)
+@inline property_dict(x) = getfield(dynamic_properties(x), :dict)
+
+is_property_dict_instantiated(x) = isdefined(dynamic_properties(x), :dict)
+is_property_dict_empty(x) = !is_property_dict_instantiated(x) || isempty(property_dict(x))
+instantiate_property_dict!(x) = setfield!(dynamic_properties(x), :dict, LittleDict{Symbol,Any}())
 
 """
     isdynamictype(T)
@@ -27,8 +25,6 @@ isdynamictype(@nospecialize T) = T isa Type && hasfield(T, DYNAMIC_PROPERTIES_FI
 Check if `x` is an instance of a dynamic type.
 """
 isdynamic(@nospecialize x) = isdynamictype(typeof(x))
-
-@inline property_dict(x) = getfield(x, DYNAMIC_PROPERTIES_FIELD_NAME).dict
 
 delproperty!(x, name::Symbol) = (delete!(property_dict(x), name); x)
 
@@ -115,57 +111,58 @@ macro dynamic(expr::Expr)
     constructors = if isempty(type_param_names)
         quote
             $struct_name($(field_type_asserts...); kwargs...) =
-                new($(fields...), $DYNAMIC_PROPERTIES(; kwargs...))
+                new($(fields...), $DynamicProperties(; kwargs...))
         end
     else
         quote
             $struct_name($(field_type_asserts...); kwargs...) where {$(type_param_names...)} =
-                new{$(type_param_names...)}($(fields...), $DYNAMIC_PROPERTIES(; kwargs...))
+                new{$(type_param_names...)}($(fields...), $DynamicProperties(; kwargs...))
                 
             $struct_name{$(type_param_names...)}($(fields...); kwargs...) where {$(type_param_names...)} =
-                new{$(type_param_names...)}($(fields...), $DYNAMIC_PROPERTIES(; kwargs...))
+                new{$(type_param_names...)}($(fields...), $DynamicProperties(; kwargs...))
         end
     end
 
-    push!(struct_body, :($DYNAMIC_PROPERTIES_FIELD_NAME::$DYNAMIC_PROPERTIES))
+    push!(struct_body, :($DYNAMIC_PROPERTIES_FIELD_NAME::$DynamicProperties))
     append!(struct_body, constructors.args)
 
     return quote
         $(esc(expr))
 
         function Base.propertynames(x::$(esc(struct_name)))
-            is_empty_property_dict(x) && return fieldnames(typeof(x))[1:end-1]
-            (fieldnames(typeof(x))[1:end-1]..., keys(property_dict(x))...)
+            is_property_dict_empty(x) && return fieldnames(typeof(x))[1:end-1]
+            (fieldnames(typeof(x))[1:end-1]..., property_dict(x).keys...)
         end
 
         function Base.propertynames(x::$(esc(struct_name)), private::Bool)
-            private && is_empty_property_dict(x) && return fieldnames(typeof(x))
-            private && return (fieldnames(typeof(x))..., keys(property_dict(x))...)
+            private && is_property_dict_empty(x) && return fieldnames(typeof(x))
+            private && return (fieldnames(typeof(x))..., property_dict(x).keys...)
             Base.propertynames(x)
         end
 
         function Base.getproperty(x::$(esc(struct_name)), name::Symbol)
             hasfield(typeof(x), name) && return getfield(x, name)
-            is_property_dict(x) && name in keys(property_dict(x)) && return @inbounds getindex(property_dict(x), name)
+            is_property_dict_instantiated(x) && name in keys(property_dict(x)) && return @inbounds getindex(property_dict(x), name)
             throw(ErrorException("$(typeof(x)) instance has no field or property $name"))
         end
 
         function Base.setproperty!(x::$(esc(struct_name)), name::Symbol, value)
             hasfield(typeof(x), name) && return setfield!(x, name, value)
-            !is_property_dict(x) && set_property_dict(x)
+            !is_property_dict_instantiated(x) && instantiate_property_dict!(x)
             setindex!(property_dict(x), value, name)
         end
 
         function Base.hash(x::$(esc(struct_name)), h::UInt)
-            !is_property_dict(x) && set_property_dict(x)
-            field_hash = foldr(hash, getfield(x, fieldname) for fieldname in fieldnames(typeof(x)); init=h)
+            dp_hash = is_property_dict_empty(x) ? h : hash(property_dict(x), h)
+            field_hash = foldr(hash, getfield(x, fieldname) for fieldname in fieldnames(typeof(x))[1:end-1]; init=dp_hash)
             hash(typeof(x), field_hash)
         end
 
         function Base.:(==)(x::$(esc(struct_name)), y::$(esc(struct_name)))
-            !is_property_dict(x) && set_property_dict(x)
-            !is_property_dict(y) && set_property_dict(y)
-            !any(name -> getfield(x, name) != getfield(y, name), fieldnames(typeof(x)))
+            x_empty, y_empty = is_property_dict_empty(x), is_property_dict_empty(y)
+            x_empty != y_empty && return false
+            !x_empty && !y_empty && property_dict(x) != property_dict(y) && return false
+            !any(name -> getfield(x, name) != getfield(y, name), fieldnames(typeof(x))[1:end-1])
         end
 
         Base.show(io::IO, x::$(esc(struct_name))) = showdynamic(io, x)

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -1,5 +1,5 @@
 mutable struct DynamicProperties
-    dict::LittleDict{Symbol,Any}
+    dict::LittleDict{Symbol,Any,Vector{Symbol},Vector{Any}}
     DynamicProperties(; kwargs...) = isempty(kwargs) ? new() : new(LittleDict{Symbol,Any}(kwargs...))
 end
 


### PR DESCRIPTION
Created from #11. Also see #10.

I was able to make the hash and == methods such that they dont need to instantiate empty dicts, by checking `is_property_dict_empty`.

I also took the opportunity to switch to `LittleDict`, as discussed in #9, which should save a lot of the memory cost of instantiating a regular `OrderedDict` for each new instance, so I'm not sure how much this lazy type is helping now. At least it doesn't need to create a `Vector{Symbol}` and a `Vector{Any}` (in the `LittleDict`) for each instance now though.

Also not sure if this technically counts as a breaking change or not.

Side note, but for the record: Ordered dictionaries are considered equal and produce the same hash irrespective of order.
```julia
julia> LittleDict(:a => 1, :b => 2) == LittleDict(:b => 2, :a => 1)
```