### PR TITLE
Move implementation details to comment in the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,6 @@ Spaceship:
     crew::Vector{String} = ["Grace"]
 ```
 
-## Implementation details
-
-The `@dynamic` macro adds a `_dynamic_properties::OrderedCollections.OrderedDict{Symbol, Any}` field to the struct definition. The `Base.getproperty` and `Base.setproperty!` methods for the new type are defined to access this dictionary when the property being accessed is not a field.
-
-A `show` method for contexts like the REPL is defined to display the fields and dynamic properties of the new type in a nice and clear format.
-
 ## See also
 
 - [DynamicObjects.jl](https://github.com/nsiccha/DynamicObjects.jl)

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -1,3 +1,10 @@
+
+# The `@dynamic` macro adds a `OrderedCollections.LittleDict{Symbol, Any, Vector{Symbol}, Vector{Any}}`
+# field to the struct definition. The `Base.getproperty` and `Base.setproperty!` methods for the
+# new type are defined to access this dictionary when the property being accessed is not a field.
+# A `show` method for contexts like the REPL is defined to display the fields and dynamic properties
+# of the new type in a nice and clear format.
+
 const DYNAMIC_PROPERTIES_FIELD_NAME = :_dynamic_properties
 
 """


### PR DESCRIPTION
I think that they are more fit to be put inside the package itself, if a user wants to know the inner workings it can look in the files